### PR TITLE
Update spotify

### DIFF
--- a/services/spotify
+++ b/services/spotify
@@ -9,3 +9,4 @@ spotify.com.edgesuite.net
 spotify.map.fastly.net
 spotify.map.fastlylb.net
 spotifycdn.net
+spotifycdn.com


### PR DESCRIPTION
DNS logs show Spotify using new CDN that should be added: heads-fa-tls13.spotifycdn.com (adding all of spotifycdn.com)
<img width="331" alt="spotify" src="https://github.com/user-attachments/assets/b118f9bc-c117-4ee2-b210-dcf8884469bf">