### PR TITLE
Add Hoichoi

### DIFF
--- a/services/hoichoi
+++ b/services/hoichoi
@@ -1,0 +1,6 @@
+hoichoi.tv
+cdn.hoichoi.tv
+api.hoichoi.tv
+static.hoichoi.tv
+video.hoichoi.tv
+hoichoi.com


### PR DESCRIPTION
## Summary
Add Hoichoi into the list of services, so that it shows up in the **Parental Control > Websites, Apps & Games**

## Changes Introduced
- Created a File called hoichoi
- Added all relevant urls needed to block hoichoi

## Context / Motivation
Hoichoi is a popular streaming platform in India, would be nice to be able to time-restrict it like other streaming platforms like Netflix, instead of putting it in the Denylist.